### PR TITLE
[Fix] 로컬 스토리지의 언어 설정에 따라 드롭다운 값 유지

### DIFF
--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -13,6 +13,11 @@ const Dropdown: React.FC<DropdownProps> = ({ options, defaultOption = '한국어
   useEffect(() => {
     if (!localStorage.getItem('language')) {
       localStorage.setItem('language', 'ko');
+    } else {
+      const storedLanguage = localStorage.getItem('language');
+      if (storedLanguage === 'ko') setSelectedOption('한국어');
+      else if (storedLanguage === 'en') setSelectedOption('English');
+      else if (storedLanguage === 'zh') setSelectedOption('中文');
     }
   }, []);
 


### PR DESCRIPTION
- useEffect에 로컬 스토리지의 language 값을 확인하는 로직 추가
- 저장된 language 코드(ko, en, zh)에 따라 드롭다운의 표시 값 설정
- 페이지 새로고침 또는 재방문 시에도 사용자 언어 선택 유지