### PR TITLE
[Merge] Dropdown Component

### DIFF
--- a/src/app/nightViewSpot/page.tsx
+++ b/src/app/nightViewSpot/page.tsx
@@ -2,10 +2,25 @@
 
 import { useEffect } from 'react';
 
-const nightViewSpot = () => {
-  useEffect(() => {}, []);
+const NightViewSpot = () => {
+  useEffect(() => {
+    const fetchNightViewSpots = async () => {
+      try {
+        const start = 1;
+        const end = 51;
+        const apiUrl = `${process.env.NEXT_PUBLIC_NIGHT_VIEW_SPOT_URL}/${start}/${end}`;
+        const res = await fetch(apiUrl);
+        const data = await res.json();
+        console.log('야경 명소 데이터:', data);
+      } catch (error) {
+        console.error('데이터 가져오기 실패:', error);
+      }
+    };
 
-  return <div>nightViewSpot</div>;
+    fetchNightViewSpots();
+  }, []);
+
+  return <div>Night View Spot</div>;
 };
 
-export default nightViewSpot;
+export default NightViewSpot;

--- a/src/app/nightViewSpot/page.tsx
+++ b/src/app/nightViewSpot/page.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { useEffect } from 'react';
+
+const nightViewSpot = () => {
+  useEffect(() => {}, []);
+
+  return <div>nightViewSpot</div>;
+};
+
+export default nightViewSpot;

--- a/src/app/nightViewSpot/page.tsx
+++ b/src/app/nightViewSpot/page.tsx
@@ -1,23 +1,20 @@
 'use client';
 
 import { useEffect } from 'react';
+import { getNightViewSpots } from '@/services/getNightViewSpots';
 
 const NightViewSpot = () => {
   useEffect(() => {
-    const fetchNightViewSpots = async () => {
+    const fetchData = async () => {
       try {
-        const start = 1;
-        const end = 51;
-        const apiUrl = `${process.env.NEXT_PUBLIC_NIGHT_VIEW_SPOT_URL}/${start}/${end}`;
-        const res = await fetch(apiUrl);
-        const data = await res.json();
+        const data = await getNightViewSpots(1, 51);
         console.log('야경 명소 데이터:', data);
       } catch (error) {
-        console.error('데이터 가져오기 실패:', error);
+        console.error('가져오기 실패:', error);
       }
     };
 
-    fetchNightViewSpots();
+    fetchData();
   }, []);
 
   return <div>Night View Spot</div>;

--- a/src/components/LanguageDropdown.tsx
+++ b/src/components/LanguageDropdown.tsx
@@ -10,10 +10,14 @@ type LanguageDropdownProps = {
 
 const LanguageDropdown: React.FC<LanguageDropdownProps> = () => {
   const [currentLanguage, setCurrentLanguage] = useState<string>('한국어');
+  const [isMounted, setIsMounted] = useState(false);
 
   useEffect(() => {
+    setIsMounted(true);
+
     const storedLanguage = localStorage.getItem('language') || 'ko';
     const foundOption = languageOptions.find(opt => opt.code === storedLanguage);
+
     if (foundOption) {
       setCurrentLanguage(foundOption.display);
     }
@@ -27,12 +31,22 @@ const LanguageDropdown: React.FC<LanguageDropdownProps> = () => {
     }
   };
 
+  if (isMounted) {
+    return (
+      <Dropdown
+        options={languageOptions.map(option => option.display)}
+        defaultOption={currentLanguage}
+        onSelect={handleLanguageSelect}
+      />
+    );
+  }
+
   return (
-    <Dropdown
-      options={languageOptions.map(option => option.display)}
-      defaultOption={currentLanguage}
-      onSelect={handleLanguageSelect}
-    />
+    <div className="relative">
+      <button className="flex items-center gap-2 w-[4.5rem] justify-between">
+        <span className="truncate">한국어</span>
+      </button>
+    </div>
   );
 };
 

--- a/src/components/LanguageDropdown.tsx
+++ b/src/components/LanguageDropdown.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+import Dropdown from './common/Dropdown';
+import { languageOptions } from '@/constants/language';
+
+type LanguageDropdownProps = {
+  buttonClassName?: string;
+  dropdownClassName?: string;
+  optionClassName?: string;
+};
+
+const LanguageDropdown: React.FC<LanguageDropdownProps> = () => {
+  const [currentLanguage, setCurrentLanguage] = useState<string>('한국어');
+
+  useEffect(() => {
+    const storedLanguage = localStorage.getItem('language') || 'ko';
+    const foundOption = languageOptions.find(opt => opt.code === storedLanguage);
+    if (foundOption) {
+      setCurrentLanguage(foundOption.display);
+    }
+  }, []);
+
+  const handleLanguageSelect = (selectedLanguage: string) => {
+    const foundOption = languageOptions.find(opt => opt.display === selectedLanguage);
+    if (foundOption) {
+      localStorage.setItem('language', foundOption.code);
+      setCurrentLanguage(selectedLanguage);
+    }
+  };
+
+  return (
+    <Dropdown
+      options={languageOptions.map(option => option.display)}
+      defaultOption={currentLanguage}
+      onSelect={handleLanguageSelect}
+    />
+  );
+};
+
+export default LanguageDropdown;

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -1,35 +1,21 @@
 import useOutsideClick from '@/hooks/useOutsideClick';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 type DropdownProps = {
   options: string[];
   defaultOption?: string;
+  onSelect?: (option: string) => void;
 };
 
-const Dropdown: React.FC<DropdownProps> = ({ options, defaultOption = '한국어' }) => {
+const Dropdown: React.FC<DropdownProps> = ({ options, defaultOption, onSelect }) => {
   const [isDropdownOpen, setIsDropdownOpen] = useState<boolean>(false);
-  const [selectedOption, setSelectedOption] = useState(defaultOption);
-
-  useEffect(() => {
-    if (!localStorage.getItem('language')) {
-      localStorage.setItem('language', 'ko');
-    } else {
-      const storedLanguage = localStorage.getItem('language');
-      if (storedLanguage === 'ko') setSelectedOption('한국어');
-      else if (storedLanguage === 'en') setSelectedOption('English');
-      else if (storedLanguage === 'zh') setSelectedOption('中文');
-    }
-  }, []);
+  const [selectedOption, setSelectedOption] = useState(defaultOption || options[0]);
 
   const dropdownRef = useOutsideClick(() => setIsDropdownOpen(false));
 
   const handleSelect = (option: string) => {
     setSelectedOption(option);
-
-    if (option === '한국어') localStorage.setItem('language', 'ko');
-    else if (option === 'English') localStorage.setItem('language', 'en');
-    else if (option === '中文') localStorage.setItem('language', 'zh');
-
+    if (onSelect) onSelect(option);
     setIsDropdownOpen(false);
   };
 

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react';
 import CornerPattern from './CornerPattern';
 import useOutsideClick from '@/hooks/useOutsideClick';
 import Dropdown from './Dropdown';
+import LanguageDropdown from '../LanguageDropdown';
 
 const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -54,8 +55,7 @@ const Header = () => {
         <div className="flex gap-4 text-sm md:text-base">
           <div className="flex items-center gap-2" tabIndex={0}>
             <Globe />
-            {/* 한국어 */}
-            <Dropdown options={['한국어', 'English', '中文']} />
+            <LanguageDropdown />
           </div>
           <button
             tabIndex={0}

--- a/src/constants/language.ts
+++ b/src/constants/language.ts
@@ -1,0 +1,10 @@
+type LanguageOption = {
+  display: string;
+  code: string;
+};
+
+export const languageOptions: LanguageOption[] = [
+  { display: '한국어', code: 'ko' },
+  { display: 'English', code: 'en' },
+  { display: '中文', code: 'zh' },
+];

--- a/src/services/getNightViewSpots.ts
+++ b/src/services/getNightViewSpots.ts
@@ -1,0 +1,18 @@
+export const getNightViewSpots = async (start: number = 1, end: number = 51) => {
+  const baseUrl = process.env.NEXT_PUBLIC_NIGHT_VIEW_SPOT_URL;
+
+  if (!baseUrl) {
+    throw new Error('야경 명소 API URL이 설정되지 않았습니다.');
+  }
+
+  const url = `${baseUrl}/${start}/${end}`;
+
+  const res = await fetch(url);
+
+  if (!res.ok) {
+    throw new Error('야경 명소 데이터를 불러오지 못했습니다.');
+  }
+
+  const data = await res.json();
+  return data;
+};


### PR DESCRIPTION
viewNightSpot 페이지 작업하다가 드롭다운 관련 먼저 pr 보냅니다.
viewNightSpot 관련 코드와 커밋은 이번 pr에서는 무시해주시길 부탁드립니다

---

### ChangeLog

재사용 가능한`Dropdown`을 생성하고 기존 `Dropdown`을 `LanguageDropdown`으로 변경했습니다.
다국어 기능을 위한 로직이 있어 따로 분리했습니다.(로컬스토리지 사용)
이 과정에서 localStorage error와 hydration error가 발생하여 해결했습니다

---

### How to use Dropdown Component


|속성|타입|필수여부|기본값|설명|
|:---:|:---:|:---:|:---:|:---:|
|options|string[]|필수|-|드롭다운에 표시할 옵션 배열
|defaultOption|string|선택|options[0]|초기 선택값
|onSelect|(option: string) => void|선택|-|옵션 선택 시 호출될 콜백 함수

```tsx
// 필수 값만 전달
<Dropdown options={options} />

// 선택 값 전달
<Dropdown options={options} defaultOption="옵션2"  />
<Dropdown options={options} defaultOption="옵션2" onSelect={()=>console.log(options)} />
```

---

### References

- [[NextJS] localStorage 에러핸들링 -localStorage is not defined-](https://velog.io/@hyo123/Next.js-localStorage-%EC%97%90%EB%9F%AC%ED%95%B8%EB%93%A4%EB%A7%81)

- [[Nextjs] react-hydration error 원인 및 해결방법 (feat. react-calendar)](https://velog.io/@juurom/TIL-react-hydration-error-%EC%9B%90%EC%9D%B8-%EB%B0%8F-%ED%95%B4%EA%B2%B0%EB%B0%A9%EB%B2%95-feat.-react-calendar)