### PR TITLE
[Feat] 시장 카드 컴포넌트 수정

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,6 @@
-import { dirname } from "path";
-import { fileURLToPath } from "url";
-import { FlatCompat } from "@eslint/eslintrc";
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { FlatCompat } from '@eslint/eslintrc';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -10,7 +10,12 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
+  ...compat.extends('next/core-web-vitals', 'next/typescript'),
+  {
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -15,6 +15,7 @@ const BasicMap = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
   const options = ['야경명소', '유적지', '전통시장'];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [data, setData] = useState<any>(nightData);
   const [markerUrl, setMarkerUrl] = useState('/images/nightMarker.png');
 
@@ -63,6 +64,7 @@ const BasicMap = () => {
 
     const ps = new kakao.maps.services.Places();
     const bounds = new kakao.maps.LatLngBounds();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const markers: any = [];
 
     const processMarket = (index: number) => {
@@ -130,7 +132,8 @@ const BasicMap = () => {
             minLevel={10} // 클러스터 할 최소 지도 레벨
           >
             {/* 기본 마커 찍기 로직 */}
-            {data.DATA.map((item: any, index: any) => (
+            {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+            {data.DATA.map((item: any, index: number) => (
               <MapMarker
                 key={index}
                 position={{
@@ -164,23 +167,31 @@ const BasicMap = () => {
 
             {/* 전통시장 마커 따로 뺌*/}
             {isMarket &&
-              marketMarkers.map((marker: any, index) => (
-                <MapMarker
-                  key={`market-${index}`}
-                  position={marker.position}
-                  image={{
-                    src: markerUrl,
-                    size: { width: 30, height: 40 },
-                  }}
-                  onClick={() => {
-                    setSelectedMarker({
-                      title: marker.title,
-                      addr: marker.location,
-                      tel_no: marker.phone,
-                    });
-                  }}
-                />
-              ))}
+              marketMarkers.map(
+                (
+                  marker: {
+                    position: { lat: number; lng: number };
+                    title: string;
+                    location: string;
+                  },
+                  index: number,
+                ) => (
+                  <MapMarker
+                    key={`market-${index}`}
+                    position={marker.position}
+                    image={{
+                      src: markerUrl,
+                      size: { width: 30, height: 40 },
+                    }}
+                    onClick={() => {
+                      setSelectedMarker({
+                        title: marker.title,
+                        addr: marker.location,
+                      });
+                    }}
+                  />
+                ),
+              )}
           </MarkerClusterer>
 
           <span className="hidden md:block absolute bg-white border border-black rounded-md text-black left-1/3 top-44 z-20">

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -82,11 +82,13 @@ const BasicMap = () => {
             lng: parseFloat(place.x),
           };
           const road_address_name = place.road_address_name;
+          const phone = place.phone || '';
 
           const markerInfo = {
             position: position,
             title: marketData.DATA[index].name,
             location: road_address_name,
+            phone: phone,
           };
 
           markers.push(markerInfo);
@@ -174,6 +176,7 @@ const BasicMap = () => {
                     setSelectedMarker({
                       title: marker.title,
                       addr: marker.location,
+                      tel_no: marker.phone,
                     });
                   }}
                 />

--- a/src/components/map/Card.tsx
+++ b/src/components/map/Card.tsx
@@ -1,6 +1,6 @@
 import { Marker } from '@/types/marker';
 
-const Card = ({ marker, src }: { marker: any; src: string }) => {
+const Card = ({ marker, src }: { marker: Marker; src: string }) => {
   const phone = marker.tel_no;
   const operating_time = marker.operating_time;
   const entr_fee = marker.entr_fee;

--- a/src/components/map/Card.tsx
+++ b/src/components/map/Card.tsx
@@ -1,6 +1,10 @@
 import { Marker } from '@/types/marker';
 
 const Card = ({ marker, src }: { marker: any; src: string }) => {
+  const phone = marker.tel_no;
+  const operating_time = marker.operating_time;
+  const entr_fee = marker.entr_fee;
+  const url = marker.url;
   return (
     <div className="flex flex-col w-full h-full bg-white border-darkBeige-1 rounded-2xl p-6 gap-6 overflow-auto text-black">
       <strong className="text-2xl font-gMedium">{marker.title}</strong>
@@ -8,15 +12,19 @@ const Card = ({ marker, src }: { marker: any; src: string }) => {
 
       <div className="flex flex-col gap-6">
         <p>주소: {marker.addr}</p>
-        <p>전화번호: {marker.tel_no}</p>
-        <p>운영시간: {marker.operating_time}</p>
-        <p>가격: {marker.entr_fee}</p>
-        <p className="break-words whitespace-normal">
-          홈페이지:{' '}
-          <a href={marker.url} className="text-xs text-realBlue">
-            {marker.url}
-          </a>
-        </p>
+        {phone ? <p>전화번호: {marker.tel_no}</p> : ''}
+        {operating_time ? <p>운영시간: {marker.operating_time}</p> : ''}
+        {entr_fee ? <p>가격: {marker.entr_fee}</p> : ''}
+        {url ? (
+          <p className="break-words whitespace-normal">
+            홈페이지:{' '}
+            <a href={marker.url} className="text-xs text-realBlue">
+              {marker.url}
+            </a>
+          </p>
+        ) : (
+          ''
+        )}
       </div>
     </div>
   );

--- a/src/components/map/DrawerMobile.tsx
+++ b/src/components/map/DrawerMobile.tsx
@@ -16,7 +16,7 @@ type DrawerMobileProps = {
   setOpen: (open: boolean) => void;
 };
 
-const DrawerMobile = ({ marker, src, open, setOpen }: any) => {
+const DrawerMobile = ({ marker, src, open, setOpen }: DrawerMobileProps) => {
   return (
     <Drawer open={open} onOpenChange={setOpen}>
       <DrawerContent>

--- a/src/types/marker.ts
+++ b/src/types/marker.ts
@@ -1,9 +1,8 @@
 export type Marker = {
-  id: string;
-  title: string;
-  addr: string;
-  tel_no: string;
-  operating_time: string;
-  entr_fee: string;
-  url: string;
+  title?: string;
+  addr?: string;
+  tel_no?: string;
+  operating_time?: string;
+  entr_fee?: string;
+  url?: string;
 };


### PR DESCRIPTION
## 수정사항
카드 컴포넌트 내 요소를 `옵셔널`로 받아 데이터가 없을 시에도 빈 공간이 생기지 않게 수정

<img width="200" alt="image" src="https://github.com/user-attachments/assets/60421e26-2d48-47c1-9de7-9666b9d0ab32" />

## 코드 변경지점

```tsx
{phone ? <p>전화번호: {marker.tel_no}</p> : ''}
        {operating_time ? <p>운영시간: {marker.operating_time}</p> : ''}
        {entr_fee ? <p>가격: {marker.entr_fee}</p> : ''}
        {url ? (
          <p className="break-words whitespace-normal">
            홈페이지:{' '}
            <a href={marker.url} className="text-xs text-realBlue">
              {marker.url}
            </a>
          </p>
        ) : (
          ''
        )}
  ```

## 변경 포인트
- `phone`이 있을 때만 `전화번호` 렌더링
- `operating_time`이 있을 때만 `운영시간` 렌더링
- `entr_fee`가 있을 때만 `가격` 렌더링
- `url`이 있을 때만 `홈페이지` 렌더링

> 데이터가 없는 경우 해당 `<p>` 요소 자체가 생성되지 않아, 레이아웃이 깨지지 않고 자연스럽게 이어집니다.

## 빌드 에러 수정

- 타입 미지정 (any)
- 선언 후 사용안함 

위와 같은 내용 수정 했습니다.