### PR TITLE
Feature/404

### DIFF
--- a/messages/common/en.json
+++ b/messages/common/en.json
@@ -8,5 +8,9 @@
     "market": "Traditional Market",
     "historicSite": "Historic Site",
     "menu": "Menu"
+  },
+  "notFound": {
+    "home": "Go back to home",
+    "notFound": "Page not found"
   }
 }

--- a/messages/common/ko.json
+++ b/messages/common/ko.json
@@ -8,5 +8,9 @@
     "market": "전통시장",
     "historicSite": "유적지",
     "menu": "메뉴"
+  },
+  "notFound": {
+    "home": "홈으로 돌아가기",
+    "notFound": "페이지를 찾을 수 없습니다"
   }
 }

--- a/messages/common/zh.json
+++ b/messages/common/zh.json
@@ -8,5 +8,9 @@
     "market": "传统市场",
     "historicSite": "历史遗址",
     "menu": "菜单"
+  },
+  "notFound": {
+    "home": "返回首页",
+    "notFound": "页面未找到"
   }
 }

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,36 +1,22 @@
-'use client';
+import Header from '@/components/common/Header';
+import NotFoundWithIntl from '@/components/NotFoundWithIntl';
+import { NextIntlClientProvider } from 'next-intl';
+import { getMessages } from 'next-intl/server';
 
-import { motion } from 'framer-motion';
-import Image from 'next/image';
+export const generateStaticParams = async () => {
+  return ['en', 'ko', 'zh'].map(locale => ({ locale }));
+};
 
-const NotFound = () => {
+const NotFound = async ({ params }: { params: Promise<{ locale: string }> }) => {
+  const resolvedParams = await params;
+  const locale = resolvedParams.locale;
+  const messages = await getMessages({ locale });
+
   return (
-    <div className="flex flex-col justify-center items-center gap-8 mt-20">
-      <div className="flex items-center gap-4 text-4xl sm:text-5xl">
-        <span>4</span>
-        <motion.div
-          animate={{ rotate: 360 }}
-          transition={{
-            duration: 2.5,
-            ease: 'linear',
-            repeat: Number.POSITIVE_INFINITY,
-            repeatType: 'loop',
-          }}
-          style={{ width: '80px', height: '80px' }}
-          className="relative"
-        >
-          <Image
-            src="/images/seoul_logo.svg"
-            alt="Seoul Logo Spinner"
-            width={50}
-            height={50}
-            className="w-full h-full"
-          />
-        </motion.div>
-        <span>4</span>
-      </div>
-      <div>Page Not Found</div>
-    </div>
+    <NextIntlClientProvider locale={locale} messages={messages}>
+      <Header />
+      <NotFoundWithIntl />
+    </NextIntlClientProvider>
   );
 };
 

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,4 +1,3 @@
-import Header from '@/components/common/Header';
 import NotFoundWithIntl from '@/components/NotFoundWithIntl';
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages } from 'next-intl/server';
@@ -13,10 +12,11 @@ const NotFound = async ({ params }: { params: Promise<{ locale: string }> }) => 
   const messages = await getMessages({ locale });
 
   return (
-    <NextIntlClientProvider locale={locale} messages={messages}>
-      <Header />
-      <NotFoundWithIntl />
-    </NextIntlClientProvider>
+    <div className="w-full h-screen flex justify-center items-center">
+      <NextIntlClientProvider locale={locale} messages={messages}>
+        <NotFoundWithIntl />
+      </NextIntlClientProvider>
+    </div>
   );
 };
 

--- a/src/components/NotFoundWithIntl.tsx
+++ b/src/components/NotFoundWithIntl.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { useTranslations } from 'next-intl';
+import Image from 'next/image';
+import Link from 'next/link';
+
+const NotFoundWithIntl = () => {
+  const tc = useTranslations('common.notFound');
+
+  return (
+    <div className="flex flex-col justify-center items-center gap-8 mt-20">
+      <div className="flex items-center gap-4 text-4xl sm:text-5xl">
+        <span>4</span>
+        <motion.div
+          animate={{ rotate: 360 }}
+          transition={{
+            duration: 2.5,
+            ease: 'linear',
+            repeat: Number.POSITIVE_INFINITY,
+            repeatType: 'loop',
+          }}
+          style={{ width: '80px', height: '80px' }}
+          className="relative"
+        >
+          <Image
+            src="/images/seoul_logo.svg"
+            alt="Seoul Logo Spinner"
+            width={50}
+            height={50}
+            className="w-full h-full"
+            priority
+          />
+        </motion.div>
+        <span>4</span>
+      </div>
+      <div>{tc('notFound')}</div>
+      <Link
+        href="/"
+        className="p-4 bg-lightBeige hover:bg-darkBeige dark:bg-lighterNavy hover:dark:bg-lightNavy rounded-xl text-xl font-gBold "
+      >
+        {tc('home')}
+      </Link>
+    </div>
+  );
+};
+
+export default NotFoundWithIntl;

--- a/src/components/NotFoundWithIntl.tsx
+++ b/src/components/NotFoundWithIntl.tsx
@@ -3,18 +3,24 @@
 import { motion } from 'framer-motion';
 import { useTranslations } from 'next-intl';
 import Image from 'next/image';
-import Link from 'next/link';
+
+import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 const NotFoundWithIntl = () => {
   const [isClient, setIsClient] = useState(false);
   const tc = useTranslations('common.notFound');
+  const router = useRouter();
 
   useEffect(() => {
     setIsClient(true);
   }, []);
 
   if (!isClient) return null;
+
+  const handleGoHome = () => {
+    router.replace('/');
+  };
 
   return (
     <div className="flex flex-col justify-center items-center gap-8">
@@ -43,12 +49,12 @@ const NotFoundWithIntl = () => {
         <span>4</span>
       </div>
       <div>{tc('notFound')}</div>
-      <Link
-        href="/"
+      <button
+        onClick={handleGoHome}
         className="p-4 bg-lightBeige hover:bg-darkBeige dark:bg-lighterNavy hover:dark:bg-lightNavy rounded-xl text-xl font-gBold "
       >
         {tc('home')}
-      </Link>
+      </button>
     </div>
   );
 };

--- a/src/components/NotFoundWithIntl.tsx
+++ b/src/components/NotFoundWithIntl.tsx
@@ -4,9 +4,17 @@ import { motion } from 'framer-motion';
 import { useTranslations } from 'next-intl';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
 
 const NotFoundWithIntl = () => {
+  const [isClient, setIsClient] = useState(false);
   const tc = useTranslations('common.notFound');
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  if (!isClient) return null;
 
   return (
     <div className="flex flex-col justify-center items-center gap-8 mt-20">

--- a/src/components/NotFoundWithIntl.tsx
+++ b/src/components/NotFoundWithIntl.tsx
@@ -17,7 +17,7 @@ const NotFoundWithIntl = () => {
   if (!isClient) return null;
 
   return (
-    <div className="flex flex-col justify-center items-center gap-8 mt-20">
+    <div className="flex flex-col justify-center items-center gap-8">
       <div className="flex items-center gap-4 text-4xl sm:text-5xl">
         <span>4</span>
         <motion.div


### PR DESCRIPTION
## 404 not-found 번역 추가
### 주요 내용
- `message/common` json 파일에 not-found 관련 번역 텍스트 추가
- 'use client'로 만들어져있던 `app/not-found.tsx` 내용 컨텐츠 컴포넌트로 분리 후 `NextIntlClientProvider` 태그 안에 추가
- `NotFoundWithIntl` 컴포넌트 내에 기존 not-found 내용 이동 및 번역 코드 추가
- hydration 에러 해결 
  -  클라이언트에서만 실행되도록 `useEffect`를 사용하여, 
  서버에서 처음 렌더링할 때는 isClient가 false로 되어 있으므로, 클라이언트에서만 해당 컴포넌트가 렌더링 되도록 함
```javascript
const [isClient, setIsClient] = useState(false);

useEffect(() => {
  setIsClient(true);
}, []);

if (!isClient) return null;

```

| 한국어 | 영어 | 중국어 |
|:-----------:|:-----------:|:-----------:|
| ![image](https://github.com/user-attachments/assets/0df90e26-60e2-4fe0-9029-7eb6e0a5c524) | ![image](https://github.com/user-attachments/assets/ceb8fc0e-4de7-4370-9646-2783d67b132c) | ![image](https://github.com/user-attachments/assets/8c0eb48a-a09e-4ca1-8386-a21dbb4b053c) |

## Thanks to
ChatGPT