### PR TITLE
[Merge] ModalContent 

### DIFF
--- a/messages/common/en.json
+++ b/messages/common/en.json
@@ -12,5 +12,15 @@
   "notFound": {
     "home": "Go back to home",
     "notFound": "Page not found"
+  },
+  "modal": {
+    "address": "Address",
+    "subway": "Subway",
+    "bus": "Bus",
+    "time": "Operating Hours",
+    "tel": "Contact",
+    "price": "Price",
+    "direction": "Directions",
+    "homepage": "Website/SNS"
   }
 }

--- a/messages/common/ko.json
+++ b/messages/common/ko.json
@@ -12,5 +12,15 @@
   "notFound": {
     "home": "홈으로 돌아가기",
     "notFound": "페이지를 찾을 수 없습니다"
+  },
+  "modal": {
+    "address": "주소",
+    "subway": "지하철",
+    "bus": "버스",
+    "time": "운영시간",
+    "tel": "문의처",
+    "price": "요금",
+    "direction": "찾아오는 길",
+    "homepage": "홈페이지/SNS"
   }
 }

--- a/messages/common/zh.json
+++ b/messages/common/zh.json
@@ -12,5 +12,15 @@
   "notFound": {
     "home": "返回首页",
     "notFound": "页面未找到"
+  },
+  "modal": {
+    "address": "地址",
+    "subway": "地铁",
+    "bus": "公交",
+    "time": "营业时间",
+    "tel": "联系方式",
+    "price": "价格",
+    "direction": "路线指引",
+    "homepage": "主页/SNS"
   }
 }

--- a/src/app/[locale]/historicSite/page.tsx
+++ b/src/app/[locale]/historicSite/page.tsx
@@ -9,15 +9,7 @@ import ModalContent from '@/components/ModalContent';
 import SkeletonGrid from '@/components/common/SkeletonGrid';
 import { useTranslations } from 'next-intl';
 import { useParams } from 'next/navigation';
-
-type SpotData = {
-  num: number;
-  title: string;
-  contents?: string;
-  la?: string;
-  lo?: string;
-  src?: string;
-};
+import { SpotData } from '@/types/spotData';
 
 const HistoricSite = () => {
   const t = useTranslations('historic');
@@ -27,6 +19,7 @@ const HistoricSite = () => {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
   const [data, setData] = useState<SpotData[]>([]);
+  const [selectedSpot, setSelectedSpot] = useState<SpotData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -70,8 +63,9 @@ const HistoricSite = () => {
     loadData();
   }, [locale, t]);
 
-  const openModal = () => {
+  const openModal = (spot: SpotData) => {
     setIsModalOpen(true);
+    setSelectedSpot(spot);
   };
 
   const closeModal = () => {
@@ -93,10 +87,10 @@ const HistoricSite = () => {
           {displayItems.map(spot => (
             <button
               key={spot.num}
-              onClick={() => openModal()}
+              onClick={() => openModal(spot)}
               className="transition-transform hover:scale-105 focus:outline-none"
             >
-              <ItemCard text={spot.title || ' '} imgSrc={spot.src} />
+              <ItemCard text={spot.title || ' '} imgSrc={spot.src || undefined} />
             </button>
           ))}
         </div>
@@ -105,7 +99,7 @@ const HistoricSite = () => {
       ) : null}
 
       <Modal isOpen={isModalOpen} onClose={closeModal}>
-        <ModalContent />
+        <ModalContent spot={selectedSpot} />
       </Modal>
     </div>
   );

--- a/src/app/[locale]/nightViewSpot/page.tsx
+++ b/src/app/[locale]/nightViewSpot/page.tsx
@@ -9,27 +9,7 @@ import ModalContent from '@/components/ModalContent';
 import SkeletonGrid from '@/components/common/SkeletonGrid';
 import { useTranslations } from 'next-intl';
 import { useParams } from 'next/navigation';
-
-type SpotData = {
-  lo: string;
-  la: string;
-  tel_no: string | null;
-  bus: string | null;
-  contents: string | null;
-  operating_time: string | null;
-  addr: string | null;
-  subject_cd: string | null;
-  reg_date: number | null;
-  url: string | null;
-  free_yn: string | null;
-  entr_fee: string | null;
-  num: number | null;
-  title: string | null;
-  subway: string | null;
-  mod_date: number | null;
-  parking_info: string | null;
-  image_url?: string;
-};
+import { SpotData } from '@/types/spotData';
 
 const NightViewSpot = () => {
   const t = useTranslations('view');
@@ -39,6 +19,7 @@ const NightViewSpot = () => {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
 
   const [data, setData] = useState<SpotData[]>([]);
+  const [selectedSpot, setSelectedSpot] = useState<SpotData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -82,8 +63,9 @@ const NightViewSpot = () => {
     loadData();
   }, [locale, t]);
 
-  const openModal = () => {
+  const openModal = (spot: SpotData) => {
     setIsModalOpen(true);
+    setSelectedSpot(spot);
   };
 
   const closeModal = () => {
@@ -105,7 +87,7 @@ const NightViewSpot = () => {
           {displayItems.map(spot => (
             <button
               key={spot.num}
-              onClick={() => openModal()}
+              onClick={() => openModal(spot)}
               className="transition-transform hover:scale-105 focus:outline-none"
             >
               <ItemCard imgSrc={spot.image_url || undefined} text={spot.title || ' '} />
@@ -117,7 +99,7 @@ const NightViewSpot = () => {
       ) : null}
 
       <Modal isOpen={isModalOpen} onClose={closeModal}>
-        <ModalContent />
+        <ModalContent spot={selectedSpot} />
       </Modal>
     </div>
   );

--- a/src/components/ModalContent.tsx
+++ b/src/components/ModalContent.tsx
@@ -24,9 +24,9 @@ const ModalContent = ({ spot }: ModalContentProps) => {
       {/* 모바일 레이아웃 */}
       <section className="flex flex-col gap-6 md:hidden">
         <h1 className="text-2xl font-gBold">{spot.title}</h1>
-        {spot.image_url ? (
+        {spot.src ? (
           <img
-            src={spot.image_url}
+            src={spot.src}
             alt={spot.title || ''}
             className="w-full h-[18rem] object-cover rounded-lg"
           />
@@ -118,9 +118,9 @@ const ModalContent = ({ spot }: ModalContentProps) => {
       {/* 데스크탑 레이아웃 */}
       <section className="hidden md:grid md:grid-cols-2 gap-6">
         <div className="flex flex-col space-y-4">
-          {spot.image_url ? (
+          {spot.src ? (
             <img
-              src={spot.image_url}
+              src={spot.src}
               alt={spot.title || ''}
               className="w-full h-[18rem] object-cover rounded-lg"
             />

--- a/src/components/ModalContent.tsx
+++ b/src/components/ModalContent.tsx
@@ -82,7 +82,7 @@ const ModalContent = ({ spot }: ModalContentProps) => {
           )}
         </div>
         <div className="flex flex-col gap-6">
-          <h2 className="text-xl font-gBold">{t('direction')}</h2>
+          {spot.addr && <h2 className="text-xl font-gBold">{t('direction')}</h2>}
           <div className="space-y-4">
             {spot.addr && (
               <div className="flex items-start gap-2">
@@ -128,7 +128,7 @@ const ModalContent = ({ spot }: ModalContentProps) => {
             <div className="w-full h-[18rem] bg-yellow rounded-lg" />
           )}
           <div className="flex flex-col gap-6">
-            <h2 className="text-xl font-gBold">{t('direction')}</h2>
+            {spot.addr && <h2 className="text-xl font-gBold">{t('direction')}</h2>}
             <div className="space-y-4">
               {spot.addr && (
                 <div className="flex items-start gap-2">

--- a/src/components/ModalContent.tsx
+++ b/src/components/ModalContent.tsx
@@ -7,82 +7,107 @@ import {
   SquareArrowOutUpRight,
   TrainFront,
 } from 'lucide-react';
+import { SpotData } from '@/types/spotData';
 
-const ModalContent = () => {
+type ModalContentProps = {
+  spot: SpotData | null;
+};
+
+const ModalContent = ({ spot }: ModalContentProps) => {
+  if (!spot) return null;
+
   return (
     <>
       {/* 모바일 레이아웃 */}
       <section className="flex flex-col gap-6 md:hidden">
-        <h1 className="text-2xl font-gBold">남산서울타워</h1>
-        <div className="w-full h-[18rem] bg-yellow rounded-lg">이미지 들어갈 공간</div>
-        <p>
-          남산서울타워는 효율적인 방송전파 송수신과 한국의 전통미를 살린 관광 전망시설의 기능을
-          겸비한 국내 최초의 종합전파 탑으로 방송문화와 관광산업의 미래를 위해 건립되었습니다. 세계
-          유명한 종합 탑들이 그 나라 또는 그 도시의 상징적인 존재가 된 것처럼 남산서울타워 역시 지난
-          40여 년간 대한민국의 대표적인 관광지이자 서울의 상징물 역할을 해왔습니다. 남산서울타워는
-          서울 시내 전 지역에서 바라보이는 탑의 높이와 독특한 구조, 형태 등으로 인하여 시민의 관심과
-          사랑의 대상이 되었고, 내외국인들이 즐겨 찾는 제1의 관광 명소로서의 위치를 확고히 하고
-          있습니다. 최근에는 한류 바람을 몰고 온 각종 예능, 드라마의 촬영지로 이름이 높아지면서
-          내외국인 관광객들이 발길이 끊이지 않는 곳입니다. (출처: 남산서울타워 홈페이지) 전망대 뿐만
-          아니라 남산공원에서 산책하면서, 남산케이블카를 이용하면서, 남산둘레길 트레킹하면서 서울의
-          야경도 다양하게 감상할 수 있습니다.
-        </p>
+        <h1 className="text-2xl font-gBold">{spot.title}</h1>
+        {spot.image_url ? (
+          <img
+            src={spot.image_url}
+            alt={spot.title || ''}
+            className="w-full h-[18rem] object-cover rounded-lg"
+          />
+        ) : (
+          <div className="w-full h-[18rem] bg-yellow rounded-lg" />
+        )}
+        {spot.contents && (
+          <div className="prose" dangerouslySetInnerHTML={{ __html: spot.contents }} />
+        )}
         <div className="space-y-4">
-          <div className="flex items-start gap-2">
-            <div className="flex items-center gap-2">
-              <Calendar />
-              <span>운영시간: </span>
+          {spot.operating_time && (
+            <div className="flex items-start gap-2">
+              <div className="flex items-center gap-2">
+                <Calendar />
+                <span>운영시간: </span>
+              </div>
+              <span className="flex-1">{spot.operating_time}</span>
             </div>
-            <span className="flex-1">연중무휴 *타워내 개별시설 운영시간 상이</span>
-          </div>
-          <div className="flex items-start gap-2">
-            <div className="flex items-center gap-2">
-              <Phone />
-              <span>문의처: </span>
+          )}
+          {spot.tel_no && (
+            <div className="flex items-start gap-2">
+              <div className="flex items-center gap-2">
+                <Phone />
+                <span>문의처: </span>
+              </div>
+              <span className="flex-1">{spot.tel_no}</span>
             </div>
-            <span className="flex-1">02-345509277, 9288</span>
-          </div>
-          <div className="flex items-start gap-2">
-            <div className="flex items-center gap-2">
-              <CircleDollarSign />
-              <span>요금: </span>
+          )}
+          {spot.entr_fee && (
+            <div className="flex items-start gap-2">
+              <div className="flex items-center gap-2">
+                <CircleDollarSign />
+                <span>요금: </span>
+              </div>
+              <span className="flex-1">{spot.entr_fee}</span>
             </div>
-            <span className="flex-1">남산공원 입장료 없음(전망대 등 개별 이용시설 요금 별도)</span>
-          </div>
-          <div className="flex items-start gap-2">
-            <div className="flex items-center gap-2">
-              <SquareArrowOutUpRight />
-              <span>홈페이지/SNS: </span>
+          )}
+          {spot.url && (
+            <div className="flex items-start gap-2">
+              <div className="flex items-center gap-2">
+                <SquareArrowOutUpRight />
+                <span>홈페이지/SNS: </span>
+              </div>
+              <a
+                className="flex-1 text-blue-600 underline"
+                href={spot.url}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {spot.url}
+              </a>
             </div>
-            <span className="flex-1">https://www.seoultower.co.kr/</span>
-          </div>
+          )}
         </div>
         <div className="flex flex-col gap-6">
           <h2 className="text-xl font-gBold">찾아오는 길</h2>
           <div className="space-y-4">
-            <div className="flex items-start gap-2">
-              <div className="flex items-center gap-2">
-                <MapPinned />
-                <span>주소: </span>
+            {spot.addr && (
+              <div className="flex items-start gap-2">
+                <div className="flex items-center gap-2">
+                  <MapPinned />
+                  <span>주소: </span>
+                </div>
+                <span className="flex-1">{spot.addr}</span>
               </div>
-              <span className="flex-1">서울특별시 용산구 남산공원길 105</span>
-            </div>
-            <div className="flex items-start gap-2">
-              <div className="flex items-center gap-2">
-                <TrainFront />
-                <span>지하철: </span>
+            )}
+            {spot.subway && (
+              <div className="flex items-start gap-2">
+                <div className="flex items-center gap-2">
+                  <TrainFront />
+                  <span>지하철: </span>
+                </div>
+                <span className="flex-1">{spot.subway}</span>
               </div>
-              <span className="flex-1">지하철 4호선 회현역에서 출구 도보 이용</span>
-            </div>
-            <div className="flex items-start gap-2">
-              <div className="flex items-center gap-2">
-                <BusFront />
-                <span>버스:</span>
+            )}
+            {spot.bus && (
+              <div className="flex items-start gap-2">
+                <div className="flex items-center gap-2">
+                  <BusFront />
+                  <span>버스:</span>
+                </div>
+                <span className="flex-1">{spot.bus}</span>
               </div>
-              <span className="flex-1">
-                남산순환버스 01A번, 01B번 이용 *남산공원 생태 환경 보호 일환으로 승용차랑 통행 제한
-              </span>
-            </div>
+            )}
           </div>
         </div>
       </section>
@@ -90,82 +115,97 @@ const ModalContent = () => {
       {/* 데스크탑 레이아웃 */}
       <section className="hidden md:grid md:grid-cols-2 gap-6">
         <div className="flex flex-col space-y-4">
-          <div className="w-full h-[18rem] bg-yellow rounded-lg">이미지 들어갈 공간</div>
+          {spot.image_url ? (
+            <img
+              src={spot.image_url}
+              alt={spot.title || ''}
+              className="w-full h-[18rem] object-cover rounded-lg"
+            />
+          ) : (
+            <div className="w-full h-[18rem] bg-yellow rounded-lg" />
+          )}
           <div className="flex flex-col gap-6">
             <h2 className="text-xl font-gBold">찾아오는 길</h2>
             <div className="space-y-4">
-              <div className="flex items-start gap-2">
-                <div className="flex items-center gap-2">
-                  <MapPinned />
-                  <span>주소: </span>
+              {spot.addr && (
+                <div className="flex items-start gap-2">
+                  <div className="flex items-center gap-2">
+                    <MapPinned />
+                    <span>주소: </span>
+                  </div>
+                  <span className="flex-1">{spot.addr}</span>
                 </div>
-                <span className="flex-1">서울특별시 용산구 남산공원길 105</span>
-              </div>
-              <div className="flex items-start gap-2">
-                <div className="flex items-center gap-2">
-                  <TrainFront />
-                  <span>지하철: </span>
+              )}
+              {spot.subway && (
+                <div className="flex items-start gap-2">
+                  <div className="flex items-center gap-2">
+                    <TrainFront />
+                    <span>지하철: </span>
+                  </div>
+                  <span className="flex-1">{spot.subway}</span>
                 </div>
-                <span className="flex-1">지하철 4호선 회현역에서 출구 도보 이용</span>
-              </div>
-              <div className="flex items-start gap-2">
-                <div className="flex items-center gap-2">
-                  <BusFront />
-                  <span>버스:</span>
+              )}
+              {spot.bus && (
+                <div className="flex items-start gap-2">
+                  <div className="flex items-center gap-2">
+                    <BusFront />
+                    <span>버스:</span>
+                  </div>
+                  <span className="flex-1">{spot.bus}</span>
                 </div>
-                <span className="flex-1">
-                  남산순환버스 01A번, 01B번 이용 *남산공원 생태 환경 보호 일환으로 승용차랑 통행
-                  제한
-                </span>
-              </div>
+              )}
             </div>
           </div>
         </div>
         <div className="flex flex-col gap-6">
-          <h1 className="text-2xl font-gBold">남산서울타워</h1>
-          <p>
-            남산서울타워는 효율적인 방송전파 송수신과 한국의 전통미를 살린 관광 전망시설의 기능을
-            겸비한 국내 최초의 종합전파 탑으로 방송문화와 관광산업의 미래를 위해 건립되었습니다.
-            세계 유명한 종합 탑들이 그 나라 또는 그 도시의 상징적인 존재가 된 것처럼 남산서울타워
-            역시 지난 40여 년간 대한민국의 대표적인 관광지이자 서울의 상징물 역할을 해왔습니다.
-            남산서울타워는 서울 시내 전 지역에서 바라보이는 탑의 높이와 독특한 구조, 형태 등으로
-            인하여 시민의 관심과 사랑의 대상이 되었고, 내외국인들이 즐겨 찾는 제1의 관광 명소로서의
-            위치를 확고히 하고 있습니다. 최근에는 한류 바람을 몰고 온 각종 예능, 드라마의 촬영지로
-            이름이 높아지면서 내외국인 관광객들이 발길이 끊이지 않는 곳입니다. (출처: 남산서울타워
-            홈페이지) 전망대 뿐만 아니라 남산공원에서 산책하면서, 남산케이블카를 이용하면서,
-            남산둘레길 트레킹하면서 서울의 야경도 다양하게 감상할 수 있습니다.
-          </p>
+          <h1 className="text-2xl font-gBold">{spot.title}</h1>
+          {spot.contents && (
+            <div className="prose" dangerouslySetInnerHTML={{ __html: spot.contents }} />
+          )}
           <div className="space-y-4">
-            <div className="flex items-start gap-2">
-              <div className="flex items-center gap-2">
-                <Calendar />
-                <span>운영시간: </span>
+            {spot.operating_time && (
+              <div className="flex items-start gap-2">
+                <div className="flex items-center gap-2">
+                  <Calendar />
+                  <span>운영시간: </span>
+                </div>
+                <span className="flex-1">{spot.operating_time}</span>
               </div>
-              <span className="flex-1">연중무휴 *타워내 개별시설 운영시간 상이</span>
-            </div>
-            <div className="flex items-start gap-2">
-              <div className="flex items-center gap-2">
-                <Phone />
-                <span>문의처: </span>
+            )}
+            {spot.tel_no && (
+              <div className="flex items-start gap-2">
+                <div className="flex items-center gap-2">
+                  <Phone />
+                  <span>문의처: </span>
+                </div>
+                <span className="flex-1">{spot.tel_no}</span>
               </div>
-              <span className="flex-1">02-345509277, 9288</span>
-            </div>
-            <div className="flex items-start gap-2">
-              <div className="flex items-center gap-2">
-                <CircleDollarSign />
-                <span>요금: </span>
+            )}
+            {spot.entr_fee && (
+              <div className="flex items-start gap-2">
+                <div className="flex items-center gap-2">
+                  <CircleDollarSign />
+                  <span>요금: </span>
+                </div>
+                <span className="flex-1">{spot.entr_fee}</span>
               </div>
-              <span className="flex-1">
-                남산공원 입장료 없음(전망대 등 개별 이용시설 요금 별도)
-              </span>
-            </div>
-            <div className="flex items-start gap-2">
-              <div className="flex items-center gap-2">
-                <SquareArrowOutUpRight />
-                <span>홈페이지/SNS: </span>
+            )}
+            {spot.url && (
+              <div className="flex items-start gap-2">
+                <div className="flex items-center gap-2">
+                  <SquareArrowOutUpRight />
+                  <span>홈페이지/SNS: </span>
+                </div>
+                <a
+                  className="flex-1 text-blue-600 underline"
+                  href={spot.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  {spot.url}
+                </a>
               </div>
-              <span className="flex-1">https://www.seoultower.co.kr/</span>
-            </div>
+            )}
           </div>
         </div>
       </section>

--- a/src/components/ModalContent.tsx
+++ b/src/components/ModalContent.tsx
@@ -8,12 +8,15 @@ import {
   TrainFront,
 } from 'lucide-react';
 import { SpotData } from '@/types/spotData';
+import { useTranslations } from 'next-intl';
 
 type ModalContentProps = {
   spot: SpotData | null;
 };
 
 const ModalContent = ({ spot }: ModalContentProps) => {
+  const t = useTranslations('common.modal');
+
   if (!spot) return null;
 
   return (
@@ -38,7 +41,7 @@ const ModalContent = ({ spot }: ModalContentProps) => {
             <div className="flex items-start gap-2">
               <div className="flex items-center gap-2">
                 <Calendar />
-                <span>운영시간: </span>
+                <span>{t('time')}: </span>
               </div>
               <span className="flex-1">{spot.operating_time}</span>
             </div>
@@ -47,7 +50,7 @@ const ModalContent = ({ spot }: ModalContentProps) => {
             <div className="flex items-start gap-2">
               <div className="flex items-center gap-2">
                 <Phone />
-                <span>문의처: </span>
+                <span>{t('tel')}: </span>
               </div>
               <span className="flex-1">{spot.tel_no}</span>
             </div>
@@ -56,7 +59,7 @@ const ModalContent = ({ spot }: ModalContentProps) => {
             <div className="flex items-start gap-2">
               <div className="flex items-center gap-2">
                 <CircleDollarSign />
-                <span>요금: </span>
+                <span>{t('price')}: </span>
               </div>
               <span className="flex-1">{spot.entr_fee}</span>
             </div>
@@ -65,7 +68,7 @@ const ModalContent = ({ spot }: ModalContentProps) => {
             <div className="flex items-start gap-2">
               <div className="flex items-center gap-2">
                 <SquareArrowOutUpRight />
-                <span>홈페이지/SNS: </span>
+                <span>{t('homepage')}: </span>
               </div>
               <a
                 className="flex-1 text-blue-600 underline"
@@ -79,13 +82,13 @@ const ModalContent = ({ spot }: ModalContentProps) => {
           )}
         </div>
         <div className="flex flex-col gap-6">
-          <h2 className="text-xl font-gBold">찾아오는 길</h2>
+          <h2 className="text-xl font-gBold">{t('direction')}</h2>
           <div className="space-y-4">
             {spot.addr && (
               <div className="flex items-start gap-2">
                 <div className="flex items-center gap-2">
                   <MapPinned />
-                  <span>주소: </span>
+                  <span>{t('address')}: </span>
                 </div>
                 <span className="flex-1">{spot.addr}</span>
               </div>
@@ -94,7 +97,7 @@ const ModalContent = ({ spot }: ModalContentProps) => {
               <div className="flex items-start gap-2">
                 <div className="flex items-center gap-2">
                   <TrainFront />
-                  <span>지하철: </span>
+                  <span>{t('subway')}: </span>
                 </div>
                 <span className="flex-1">{spot.subway}</span>
               </div>
@@ -103,7 +106,7 @@ const ModalContent = ({ spot }: ModalContentProps) => {
               <div className="flex items-start gap-2">
                 <div className="flex items-center gap-2">
                   <BusFront />
-                  <span>버스:</span>
+                  <span>{t('bus')}:</span>
                 </div>
                 <span className="flex-1">{spot.bus}</span>
               </div>
@@ -125,13 +128,13 @@ const ModalContent = ({ spot }: ModalContentProps) => {
             <div className="w-full h-[18rem] bg-yellow rounded-lg" />
           )}
           <div className="flex flex-col gap-6">
-            <h2 className="text-xl font-gBold">찾아오는 길</h2>
+            <h2 className="text-xl font-gBold">{t('direction')}</h2>
             <div className="space-y-4">
               {spot.addr && (
                 <div className="flex items-start gap-2">
                   <div className="flex items-center gap-2">
                     <MapPinned />
-                    <span>주소: </span>
+                    <span>{t('address')}: </span>
                   </div>
                   <span className="flex-1">{spot.addr}</span>
                 </div>
@@ -140,7 +143,7 @@ const ModalContent = ({ spot }: ModalContentProps) => {
                 <div className="flex items-start gap-2">
                   <div className="flex items-center gap-2">
                     <TrainFront />
-                    <span>지하철: </span>
+                    <span>{t('subway')}: </span>
                   </div>
                   <span className="flex-1">{spot.subway}</span>
                 </div>
@@ -149,7 +152,7 @@ const ModalContent = ({ spot }: ModalContentProps) => {
                 <div className="flex items-start gap-2">
                   <div className="flex items-center gap-2">
                     <BusFront />
-                    <span>버스:</span>
+                    <span>{t('bus')}:</span>
                   </div>
                   <span className="flex-1">{spot.bus}</span>
                 </div>
@@ -167,7 +170,7 @@ const ModalContent = ({ spot }: ModalContentProps) => {
               <div className="flex items-start gap-2">
                 <div className="flex items-center gap-2">
                   <Calendar />
-                  <span>운영시간: </span>
+                  <span>{t('time')}: </span>
                 </div>
                 <span className="flex-1">{spot.operating_time}</span>
               </div>
@@ -176,7 +179,7 @@ const ModalContent = ({ spot }: ModalContentProps) => {
               <div className="flex items-start gap-2">
                 <div className="flex items-center gap-2">
                   <Phone />
-                  <span>문의처: </span>
+                  <span>{t('tel')}: </span>
                 </div>
                 <span className="flex-1">{spot.tel_no}</span>
               </div>
@@ -185,7 +188,7 @@ const ModalContent = ({ spot }: ModalContentProps) => {
               <div className="flex items-start gap-2">
                 <div className="flex items-center gap-2">
                   <CircleDollarSign />
-                  <span>요금: </span>
+                  <span>{t('price')}: </span>
                 </div>
                 <span className="flex-1">{spot.entr_fee}</span>
               </div>
@@ -194,7 +197,7 @@ const ModalContent = ({ spot }: ModalContentProps) => {
               <div className="flex items-start gap-2">
                 <div className="flex items-center gap-2">
                   <SquareArrowOutUpRight />
-                  <span>홈페이지/SNS: </span>
+                  <span>{t('homepage')}: </span>
                 </div>
                 <a
                   className="flex-1 text-blue-600 underline"

--- a/src/types/spotData.ts
+++ b/src/types/spotData.ts
@@ -1,0 +1,21 @@
+export type SpotData = {
+  num: number | null;
+  title: string | null;
+  contents?: string | null;
+  la?: string | null;
+  lo?: string | null;
+  src?: string | null;
+  tel_no?: string | null;
+  bus?: string | null;
+  operating_time?: string | null;
+  addr?: string | null;
+  subject_cd?: string | null;
+  reg_date?: number | null;
+  url?: string | null;
+  free_yn?: string | null;
+  entr_fee?: string | null;
+  subway?: string | null;
+  mod_date?: number | null;
+  parking_info?: string | null;
+  image_url?: string | null;
+};


### PR DESCRIPTION
## ModalContent 작업 내용 

### 주요 변경사항

### 1. 타입 분리 및 통합
- `src/types/spotData.ts`에 SpotData 타입 정의
- 야경명소, 유적지 등 모든 페이지에서 공통으로 사용할 수 있도록 타입 통합

### 2. 다국어 지원
- 각 언어별 common json에 modal 관련 번역 추가
- `useTranslations` 훅을 사용하여 모달 내용 다국어 지원
- 예시: json(ko)

```
"modal": {
    "address": "주소",
    "subway": "지하철",
    "bus": "버스",
    "time": "운영시간",
    "tel": "문의처",
    "price": "요금",
    "direction": "찾아오는 길",
    "homepage": "홈페이지/SNS"
  }
```

### 3. 조건부 렌더링
- 유적지 페이지의 경우 주소, 버스, 지하철 데이터가 없어 `찾아오는 길(common.modal.direction)` 섹션 조건부 렌더링
- 각 데이터 필드 존재 여부에 따라 관련 섹션 표시/숨김 처리


## 테스트 방법
1. 각 페이지(야경명소, 유적지)에서 카드 클릭
2. 모달 내용이 데이터에 맞게 표시되는지 확인
3. 다국어 전환 시 모달 내용이 올바르게 번역되는지 확인
4. 유적지 페이지에서 `찾아오는 길` 섹션이 숨겨지는지 확인

## 미리보기

| ko | en | zh |
|:--:|:--:|:--:|
| <img src="https://github.com/user-attachments/assets/3d573a0c-3ef7-4ed5-84c1-50c629038e74" width="300" /> | <img src="https://github.com/user-attachments/assets/8b6ccdef-726d-4ee6-8ac3-72294a337ed7" width="300" /> | <img src="https://github.com/user-attachments/assets/896a2594-3f36-4d6c-8fcb-f6f8d93db09d" width="300" /> |
| <img src="https://github.com/user-attachments/assets/5f1a2c81-4908-4782-abc4-a48eec0e31ac" width="300" /> | <img src="https://github.com/user-attachments/assets/d2161afa-dae1-47ba-a854-28255cfc078f" width="300" /> | <img src="https://github.com/user-attachments/assets/4a7364b4-9c28-489e-a88a-3ef5de64e908" width="300" /> |


## 관련 이슈

#41 