### PR TITLE
[Feat] 라이트/다크 모드 변환가능 토글 구현

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,17 +1,20 @@
 'use client';
 
 import Link from 'next/link';
-import { Globe, Menu, ChevronRight } from 'lucide-react';
-import { useState } from 'react';
+import { Globe, Menu, ChevronRight, Sun, Moon } from 'lucide-react';
+import { useEffect, useState } from 'react';
 import CornerPattern from './CornerPattern';
 import useOutsideClick from '@/hooks/useOutsideClick';
 import LanguageDropdown from '../LanguageDropdown';
 import { usePathname } from 'next/navigation';
 import { useTranslations } from 'next-intl';
+import { useTheme } from 'next-themes';
 
 const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isMounted, setIsMounted] = useState(false);
   const pathname = usePathname();
+  const { theme, setTheme } = useTheme();
 
   const tc = useTranslations('common.header');
 
@@ -28,6 +31,10 @@ const Header = () => {
       handleCloseMenu();
     }
   };
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
 
   const menuRef = useOutsideClick(() => setIsMenuOpen(false));
 
@@ -88,6 +95,15 @@ const Header = () => {
         </nav>
 
         <div className="flex gap-4 text-sm md:text-base">
+          {isMounted && (
+            <button
+              onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+              aria-label={theme === 'dark' ? '라이트 모드로 전환' : '다크 모드로 전환'}
+              tabIndex={0}
+            >
+              {theme === 'dark' ? <Sun /> : <Moon />}
+            </button>
+          )}
           <div className="flex items-center gap-2" tabIndex={0}>
             <Globe />
             <LanguageDropdown />

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from 'tailwindcss';
 
 const config: Config = {
+  darkMode: 'class',
   content: ['./src/**/*.{js,ts,jsx,tsx,mdx}'],
   theme: {
     extend: {


### PR DESCRIPTION
## 라이트/다크 모드 토글
### 구현내용
- header에 라이트/다크 모드 변환이 가능한 토글 버튼을 추가하였습니다

### 화면
<img width="400" alt="스크린샷 2025-05-05 오후 8 38 27" src="https://github.com/user-attachments/assets/a944505d-4d93-4066-83b8-fc57f6e9babc" />
<img width="400" alt="스크린샷 2025-05-05 오후 8 38 37" src="https://github.com/user-attachments/assets/ad8f0d5c-4167-4b39-b3ad-220eaba56239" />
