### PR TITLE
Feature/dropdown

### DIFF
--- a/src/components/LanguageDropdown.tsx
+++ b/src/components/LanguageDropdown.tsx
@@ -43,6 +43,7 @@ const LanguageDropdown: React.FC<LanguageDropdownProps> = () => {
         options={languageOptions.map(option => option.display)}
         defaultOption={currentLanguage}
         onSelect={handleLanguageSelect}
+        variant="language"
       />
     );
   }

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -1,13 +1,21 @@
 import useOutsideClick from '@/hooks/useOutsideClick';
+import clsx from 'clsx';
+import { Globe } from 'lucide-react';
 import { useState } from 'react';
 
 type DropdownProps = {
   options: string[];
   defaultOption?: string;
   onSelect?: (option: string) => void;
+  variant?: 'default' | 'language';
 };
 
-const Dropdown: React.FC<DropdownProps> = ({ options, defaultOption, onSelect }) => {
+const Dropdown: React.FC<DropdownProps> = ({
+  options,
+  defaultOption,
+  onSelect,
+  variant = 'default',
+}) => {
   const [isDropdownOpen, setIsDropdownOpen] = useState<boolean>(false);
   const [selectedOption, setSelectedOption] = useState(defaultOption || options[0]);
 
@@ -23,13 +31,17 @@ const Dropdown: React.FC<DropdownProps> = ({ options, defaultOption, onSelect })
     <article className="relative" ref={dropdownRef}>
       <button
         onClick={() => setIsDropdownOpen(!isDropdownOpen)}
-        className="flex items-center gap-2 w-[4.5rem] justify-center"
+        className={clsx(
+          'flex items-center  gap-2',
+          variant === 'default' ? 'justify-center px-2' : 'w-[6rem] justify-start',
+        )}
       >
-        <span className="truncate">{selectedOption}</span>
+        {variant === 'language' && <Globe />}
+        <span className="flex justify-center items-center">{selectedOption}</span>
       </button>
 
       {isDropdownOpen && (
-        <ul className="absolute top-full -left-4 lg:-left-8 mt-1 bg-lightBeige text-navy py-1 w-[6rem] z-30">
+        <ul className="absolute top-full -left-4 mt-1 bg-lightBeige text-navy py-1 w-[6rem] z-30">
           {options.map(option => (
             <li key={option}>
               <button

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -41,7 +41,7 @@ const Dropdown: React.FC<DropdownProps> = ({
       </button>
 
       {isDropdownOpen && (
-        <ul className="absolute top-full -left-4 mt-1 bg-lightBeige text-navy py-1 w-auto whitespace-nowrap z-30">
+        <ul className="absolute top-full mt-1 bg-lightBeige text-navy py-1 w-auto whitespace-nowrap z-30">
           {options.map(option => (
             <li key={option}>
               <button

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -41,7 +41,7 @@ const Dropdown: React.FC<DropdownProps> = ({
       </button>
 
       {isDropdownOpen && (
-        <ul className="absolute top-full -left-4 mt-1 bg-lightBeige text-navy py-1 w-[6rem] z-30">
+        <ul className="absolute top-full -left-4 mt-1 bg-lightBeige text-navy py-1 w-auto whitespace-nowrap z-30">
           {options.map(option => (
             <li key={option}>
               <button

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -16,6 +16,13 @@ const Header = () => {
   const pathname = usePathname();
   const { theme, setTheme } = useTheme();
 
+  const [locale, setLocale] = useState('ko');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('language') || 'ko';
+    setLocale(stored);
+  }, []);
+
   const tc = useTranslations('common.header');
 
   const handleOpenMenu = () => {
@@ -51,7 +58,11 @@ const Header = () => {
           프로젝트 이름
         </Link>
 
-        <nav className="hidden lg:flex flex-row gap-16 text-lg">
+        <nav
+          className={`hidden ${locale === 'en' ? 'xl:flex' : 'lg:flex'} flex-row gap-16 ${
+            locale === 'en' ? 'text-base' : 'text-lg'
+          }`}
+        >
           <Link href="/map" className="group relative" tabIndex={0}>
             {tc('map')}
             <span
@@ -110,7 +121,9 @@ const Header = () => {
           <button
             tabIndex={0}
             onClick={handleOpenMenu}
-            className="lg:hidden flex items-center justify-center"
+            className={`${
+              locale === 'en' ? 'xl:hidden' : 'lg:hidden'
+            } flex items-center justify-center`}
           >
             <Menu />
           </button>
@@ -118,10 +131,16 @@ const Header = () => {
 
         {isMenuOpen && (
           <>
-            <div className="lg:hidden fixed top-0 left-0 w-screen h-screen bg-black opacity-20 z-40" />
+            <div
+              className={`${
+                locale === 'en' ? 'xl:hidden' : 'lg:hidden'
+              } fixed top-0 left-0 w-screen h-screen bg-black opacity-20 z-40`}
+            />
             <div
               ref={menuRef}
-              className="fixed top-0 right-0 w-[80%] max-w-96 h-full p-8 border-2 border-darkerBrown bg-darkBrown transform lg:hidden z-50"
+              className={`fixed top-0 right-0 w-[80%] max-w-96 h-full p-8 border-2 border-darkerBrown bg-darkBrown transform ${
+                locale === 'en' ? 'xl:hidden' : 'lg:hidden'
+              } z-50`}
             >
               <button tabIndex={0} onClick={handleCloseMenu} className="absolute top-1/2 left-0 ">
                 <ChevronRight className="w-8 h-8 text-navy" />

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { Globe, Menu, ChevronRight, Sun, Moon } from 'lucide-react';
+import { Menu, ChevronRight, Sun, Moon } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import CornerPattern from './CornerPattern';
 import useOutsideClick from '@/hooks/useOutsideClick';
@@ -105,7 +105,6 @@ const Header = () => {
             </button>
           )}
           <div className="flex items-center gap-2" tabIndex={0}>
-            <Globe />
             <LanguageDropdown />
           </div>
           <button


### PR DESCRIPTION
## 드롭다운 레이아웃 수정 및 헤더 수정
### 드롭다운 변경 내용
- 언어 선택 메뉴 및 드롭다운 위치 수정
- `globe` 아이콘 클릭시에도 드롭다운 나타나도록 `cva`, `clsx`를 활용하여 속성 수정

| 한국어 | 영어 | 중국어 |
|:-----------:|:-----------:|:-----------:|
| ![image](https://github.com/user-attachments/assets/188bd802-6ccd-4a07-a3fa-ed168377b147) |  ![image](https://github.com/user-attachments/assets/1bd4f54b-9570-4481-89ac-cb435476e348) | ![image](https://github.com/user-attachments/assets/4d0316d0-f084-472a-a4b0-05511f816625) |

- 지도 드롭다운 선택 메뉴 px 추가(여백) 및 드롭다운 컨텐츠 길이 맞춤 속성 추가

| 한국어 | 영어 | 중국어 |
|:-----------:|:-----------:|:-----------:|
| ![image](https://github.com/user-attachments/assets/dec581d6-d040-4bbd-ac2d-962ff0f504f7) |  ![image](https://github.com/user-attachments/assets/4c351e33-e736-4f8a-840f-1ee23bdffea0) | ![image](https://github.com/user-attachments/assets/30b3669c-c817-45c0-8710-ac52fca858cc) |

### 헤더 변경 내용
- 영어가 길어짐에 따라 햄버거 메뉴 노출 시점 조정 (기존 breakpoint `lg` -> `xl`, 영어만)

| 기본 | 햄버거 메뉴 | 
|:-----------:|:-----------:|
| ![image](https://github.com/user-attachments/assets/d985f221-2f4e-435c-9059-f85b2302299c) |  ![image](https://github.com/user-attachments/assets/c84ca176-e416-4ade-80eb-ce9f769cb917) |
